### PR TITLE
feat(flake.nix): created flake.nix to install with *nix sysms

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  description = "Tuicam - Terminal-based camera with switchable modes";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+    in {
+      packages = {
+        tuicam = pkgs.rustPlatform.buildRustPackage {
+          pname = "tuicam";
+          version = "0.0.1";
+          src = ./.;
+          cargoHash = "sha256-wGXRFCirIZ6tWYK73CZJD5Pzx1Nu5iooeZ+Esijfgtw=";
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            llvmPackages.llvm
+            clang
+          ];
+
+          buildInputs = with pkgs; [
+            opencv
+            udev
+            llvmPackages.libclang
+          ];
+
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+          BINDGEN_EXTRA_CLANG_ARGS = ''-I${pkgs.llvmPackages.libclang.lib}/lib/clang/${pkgs.llvmPackages.libclang.version}/include'';
+          RUSTFLAGS = ''--cfg=libclang_path="${pkgs.llvmPackages.libclang.lib}/lib"'';
+
+          preBuildPhases = ["setEnvVars"];
+          setEnvVars = ''
+            export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib"
+            export BINDGEN_EXTRA_CLANG_ARGS="-I${pkgs.llvmPackages.libclang.lib}/lib/clang/${pkgs.llvmPackages.libclang.version}/include"
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Terminal-based camera with switchable modes";
+            license = licenses.mit;
+            maintainers = with maintainers; [hlsxx];
+            platforms = platforms.linux;
+          };
+        };
+      };
+
+      apps = {
+        default = flake-utils.lib.mkApp {
+          drv = self.packages.${system}.tuicam;
+          program = "tuicam";
+        };
+      };
+    });
+}


### PR DESCRIPTION
I made a flake to install with *nix systems. Install instructions:

## Installation on NixOS/Nix

### Using Flakes (recommended)
To use as a flake in your system, add it to your `flake.nix`:

```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
    tuicam.url = "github:hlsxx/tuicam";
  };

  outputs = { self, nixpkgs, tuicam }: {
    # For NixOS system configuration
    nixosConfigurations.yourSystem = nixpkgs.lib.nixosSystem {
      # ...
      environment.systemPackages = [ tuicam.packages.${system}.tuicam ];
    };

    # Or for home-manager
    homeConfigurations.yourUser = {
      # ...
      home.packages = [ tuicam.packages.${system}.tuicam ];
    };
  };
}
```

### Direct Installation
You can also install or run directly:

```bash
# Run directly
nix run github:hlsxx/tuicam

# Install to profile
nix profile install github:hlsxx/tuicam
```

### Local Installation
Clone the repository and build locally:

```bash
# Clone the repository
git clone https://github.com/hlsxx/tuicam
cd tuicam

# Build and run with flakes
nix run .#

# Or install to profile from local source
nix profile install .#
```
